### PR TITLE
Udp

### DIFF
--- a/src-flask-server/app.py
+++ b/src-flask-server/app.py
@@ -989,6 +989,8 @@ class MultiGameClass:
                     if test_code == str(sid):
                         test_code = '2'
                         b += 1
+                        if b > 5:
+                            break
                 except socket.timeout:
                     a += 1
     

--- a/src-flask-server/app.py
+++ b/src-flask-server/app.py
@@ -1448,6 +1448,7 @@ def snake():
     def generate():
         global multi
         global start
+        start = False
         skill_cnt = 0
         opp_skill_cnt = 0
 

--- a/src-flask-server/app.py
+++ b/src-flask-server/app.py
@@ -978,19 +978,38 @@ class MultiGameClass:
         b = 0
         test_code = str(sid)
 
-        for i in range(50):
-            if i % 2 == 0 and b != 0:
-                test_code = str(sid)
-            self.sock.sendto(test_code.encode(), self.opp_addr)
-            try:
-                data, _ = self.sock.recvfrom(100)
-                test_code = data.decode()
-                if test_code == str(sid):
-                    b += 1
-            except socket.timeout:
-                a += 1
+        if test_code == "1":
+            for i in range(50):
+                if i % 3 == 0 and b == 0:
+                    test_code = '1'
+                self.sock.sendto(test_code.encode(), self.opp_addr)
+                try:
+                    data, _ = self.sock.recvfrom(100)
+                    test_code = data.decode()
+                    if test_code == str(sid):
+                        test_code = '2'
+                        b += 1
+                except socket.timeout:
+                    a += 1
+    
+        elif test_code == "2":
+            for i in range(50):
+                if i % 3 == 0 and b == 0:
+                    test_code = '2'
+                self.sock.sendto(test_code.encode(), self.opp_addr)
+                try:
+                    data, _ = self.sock.recvfrom(100)
+                    test_code = data.decode()
+                    if test_code == str(sid):
+                        test_code = '1'
+                        b += 1
+                        if b > 5:
+                            break
+                except socket.timeout:
+                    a += 1
+        
 
-        if a != 50 and b != 0:
+        if b != 0:
             self.is_udp = True
 
         self.sock.settimeout(0.01)

--- a/src-flask-server/app.py
+++ b/src-flask-server/app.py
@@ -989,7 +989,7 @@ class MultiGameClass:
                     if test_code == str(sid):
                         test_code = '2'
                         b += 1
-                        if b > 5:
+                        if b > 3:
                             break
                 except socket.timeout:
                     a += 1
@@ -1005,7 +1005,7 @@ class MultiGameClass:
                     if test_code == str(sid):
                         test_code = '1'
                         b += 1
-                        if b > 5:
+                        if b > 3:
                             break
                 except socket.timeout:
                     a += 1
@@ -1015,7 +1015,7 @@ class MultiGameClass:
             self.is_udp = True
 
         self.sock.settimeout(0.01)
-        for _ in range(100):
+        for _ in range(50):
             self.sock.recv(0)
         self.sock.settimeout(0)
 
@@ -1174,6 +1174,7 @@ class MultiGameClass:
                 self.opp_points = eval(decode_data)
                 self.udp_count = 0
             else:
+                print('----------else--------')
                 self.udp_count = 0
         except socket.timeout:
             self.udp_count += 1

--- a/src-flask-server/app.py
+++ b/src-flask-server/app.py
@@ -1010,7 +1010,6 @@ class MultiGameClass:
                 except socket.timeout:
                     a += 1
         
-
         if b != 0:
             self.is_udp = True
             self.sock.settimeout(0.01)

--- a/src-flask-server/app.py
+++ b/src-flask-server/app.py
@@ -1013,11 +1013,10 @@ class MultiGameClass:
 
         if b != 0:
             self.is_udp = True
-
-        self.sock.settimeout(0.01)
-        for _ in range(50):
-            self.sock.recv(0)
-        self.sock.settimeout(0)
+            self.sock.settimeout(0.01)
+            for _ in range(50):
+                self.sock.recv(0)
+            self.sock.settimeout(0)
 
         print(f"connection MODE : {self.is_udp} / a = {a}, b = {b}")
         socketio.emit('NetworkMode', {'UDP': self.is_udp})


### PR DESCRIPTION
udp에서 한명만 느린 이유는 두 개의 뱀 중 네트워크와 관련이 있는 뱀은 상대 뱀인데 udp 통신에서 인터넷이 느린 클라이언트가 1p, 인터넷이 빠른 클라이언트가 2p라고 할때 2p의 화면에서 상대 뱀이 높은 레이턴시를 갖는 것이 확인됨. 이 경우 네트워크 부분에서의 통신 속도가 문제가 되는 것이기 때문에 테스트에서 udp 통신을 결정하는 결정 요소로 속도를 추가해 일정 속도 이하인 경우 udp 통신을 하지 않고 서버로 연결하는 것이 최적으로 판단됨.

이번 커밋의 경우, udp 체크 활성화 및 커넥트 검사 시간을 줄이는 (로직 개선) 작업에 관한 커밋 (일정속도 이하인 경우 검사 X)

udp 연결을 완전히 제외하기를 바라는 경우
app.py 에 1405 줄에 있는
multi.set_socket(MY_PORT, opp_ip, opp_port)
multi.test_connect(sid)
위 두 줄을 주석처리하고 그 아래에 
socketio.emit('game_ready')
위와 같은 코드를 작성할 시 udp 검사를 하지 않고 즉시 서버 연결을 통한 게임을 진행함.
